### PR TITLE
Update - 设置时间单位为time.Second

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rc := rockscache.NewClient(redisClient, NewDefaultOptions())
 // 1. the first parameter is the key of the data
 // 2. the second parameter is the data expiration time
 // 3. the third parameter is the data fetch function which is called when the cache does not exist
-v, err := rc.Fetch("key1", 300, func()(string, error) {
+v, err := rc.Fetch("key1", 300 * time.Second, func()(string, error) {
   // fetch data from database or other sources
   return "value1", nil
 })


### PR DESCRIPTION
```
import "github.com/dtm-labs/rockscache"

// new a client for rockscache using the default options
rc := rockscache.NewClient(redisClient, NewDefaultOptions())

// use Fetch to fetch data
// 1. the first parameter is the key of the data
// 2. the second parameter is the data expiration time
// 3. the third parameter is the data fetch function which is called when the cache does not exist
v, err := rc.Fetch("key1", 300, func()(string, error) {
  // fetch data from database or other sources
  return "value1", nil
})
```
这里Fetch函数的第二个参数类型是time.Duration，如果传递时没有指定time.Second的话，会被默认转换为纳秒，即300ns，就会导致设置的key立即过期。