### PR TITLE
Add batch processing

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -156,8 +156,8 @@ func (c *Client) strongFetchBatch(ctx context.Context, keys []string, expire tim
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range fetched {
-			result[k] = v
+		for _, k := range toFetch {
+			result[k] = fetched[k]
 		}
 	}
 

--- a/batch.go
+++ b/batch.go
@@ -347,10 +347,19 @@ func (c *Client) strongFetchBatch(ctx context.Context, keys []string, expire tim
 	return result, nil
 }
 
+// FetchBatch returns a map with values indexed by index of keys list.
+// 1. the first parameter is the keys list of the data
+// 2. the second parameter is the data expiration time
+// 3. the third parameter is the batch data fetch function which is called when the cache does not exist
+// the parameter of the batch data fetch function is the index list of those keys
+// missing in cache, which can be used to form a batch query for missing data.
+// the return value of the batch data fetch function is a map, with key of the
+// index and value of the corresponding data in form of string
 func (c *Client) FetchBatch(keys []string, expire time.Duration, fn func(idxs []int) (map[int]string, error)) (map[int]string, error) {
 	return c.FetchBatch2(c.rdb.Context(), keys, expire, fn)
 }
 
+// FetchBatch2 is same with FetchBatch, except that a user defined context.Context can be provided.
 func (c *Client) FetchBatch2(ctx context.Context, keys []string, expire time.Duration, fn func(idxs []int) (map[int]string, error)) (map[int]string, error) {
 	if c.Options.DisableCacheRead {
 		return fn(c.keysIdx(keys))
@@ -360,11 +369,12 @@ func (c *Client) FetchBatch2(ctx context.Context, keys []string, expire time.Dur
 	return c.weakFetchBatch(ctx, keys, expire, fn)
 }
 
+// TagAsDeletedBatch a key list, the keys in list will expire after delay time.
 func (c *Client) TagAsDeletedBatch(keys []string) error {
 	return c.TagAsDeletedBatch2(c.rdb.Context(), keys)
 }
 
-// TagAsDeleted2 a key, the key will expire after delay time.
+// TagAsDeletedBatch2 a key list, the keys in list will expire after delay time.
 func (c *Client) TagAsDeletedBatch2(ctx context.Context, keys []string) error {
 	if c.Options.DisableCacheDelete {
 		return nil

--- a/batch.go
+++ b/batch.go
@@ -32,7 +32,7 @@ func (c *Client) luaGetBatch(ctx context.Context, keys []string, owner string) (
     end
     return rets
 	`, keys, []interface{}{now(), now() + int64(c.Options.LockExpire/time.Second), owner})
-	debugf("luaGet return: %v, %v", res, err)
+	debugf("luaGetBatch return: %v, %v", res, err)
 	if err != nil {
 		return nil, err
 	}
@@ -156,8 +156,8 @@ func (c *Client) strongFetchBatch(ctx context.Context, keys []string, expire tim
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range fetched {
-			result[k] = v
+		for _, k := range toFetch {
+			result[k] = fetched[k]
 		}
 		toFetch = toFetch[:0] // reset toFetch
 	}

--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,177 @@
+package rockscache
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/lithammer/shortuuid"
+)
+
+var (
+	errNeedFetch = errors.New("need fetch")
+)
+
+func (c *Client) fetchBatch(ctx context.Context, keys []string, idxs []int, expire time.Duration, owner string, fn func(idxs []int) (map[int]string, error)) (map[int]string, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			debug.PrintStack()
+		}
+	}()
+	data, err := fn(idxs)
+	if err != nil {
+		for _, idx := range idxs {
+			_ = c.UnlockForUpdate(ctx, keys[idx], owner)
+		}
+		return nil, err
+	}
+
+	if data == nil {
+		// incase data is nil
+		data = make(map[int]string)
+	}
+
+	for _, idx := range idxs {
+		v := data[idx]
+		ex := expire - c.Options.Delay - time.Duration(rand.Float64()*c.Options.RandomExpireAdjustment*float64(expire))
+		if v == "" {
+			if c.Options.EmptyExpire == 0 { // if empty expire is 0, then delete the key
+				_ = c.rdb.Del(ctx, keys[idx]).Err()
+				if err != nil {
+					debugf("batch: del failed key=%s err:%s", keys[idx], err.Error())
+				}
+				continue
+			}
+			ex = c.Options.EmptyExpire
+
+			data[idx] = v // incase idx not in data
+		}
+		err = c.luaSet(ctx, keys[idx], v, int(ex/time.Second), owner)
+		if err != nil {
+			debugf("batch: luaSet failed key=%s err:%s", keys[idx], err.Error())
+		}
+	}
+	return data, nil
+}
+
+func (c *Client) keysIdx(keys []string) (idxs []int) {
+	for i := range keys {
+		idxs = append(idxs, i)
+	}
+	return idxs
+}
+
+func (c *Client) strongFetchBatch(ctx context.Context, keys []string, expire time.Duration, fn func(idxs []int) (map[int]string, error)) (map[int]string, error) {
+	debugf("batch: strongFetch keys=%+v", keys)
+	var result = make(map[int]string)
+	owner := shortuuid.New()
+	var idxs = c.keysIdx(keys)
+	var toGet, toFetch []int
+
+	// read from redis without sleep
+	for _, idx := range idxs {
+		r, err := c.luaGet(ctx, keys[idx], owner)
+		if err != nil {
+			return nil, err
+		}
+
+		if r[1] == nil { // normal value
+			result[idx] = r[0].(string)
+			continue
+		}
+
+		if r[1] != locked { // locked by other
+			debugf("batch: locked by other, continue idx=%d", idx)
+			toGet = append(toGet, idx)
+			continue
+		}
+
+		// locked for fetch
+		toFetch = append(toFetch, idx)
+	}
+
+	if len(toFetch) > 0 {
+		// batch fetch
+		fetched, err := c.fetchBatch(ctx, keys, toFetch, expire, owner, fn)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range fetched {
+			result[k] = v
+		}
+		toFetch = toFetch[:0] // reset toFetch
+	}
+
+	if len(toGet) > 0 {
+		// read from redis and sleep to wait
+		var wg sync.WaitGroup
+		type pair struct {
+			idx  int
+			data string
+			err  error
+		}
+		var ch = make(chan pair, len(toGet))
+		for _, idx := range toGet {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				r, err := c.luaGet(ctx, keys[i], owner)
+				for err == nil && r[1] != nil && r[1] != locked { // locked by other
+					debugf("batch: locked by other, so sleep %s", c.Options.LockSleep)
+					time.Sleep(c.Options.LockSleep)
+					r, err = c.luaGet(ctx, keys[i], owner)
+				}
+				if err != nil {
+					ch <- pair{idx: i, data: "", err: err}
+					return
+				}
+				if r[1] != locked { // normal value
+					ch <- pair{idx: i, data: r[0].(string), err: nil}
+					return
+				}
+				// locked for update
+				ch <- pair{idx: i, data: "", err: errNeedFetch}
+			}(idx)
+		}
+		wg.Wait()
+		close(ch)
+		for p := range ch {
+			if p.err != nil {
+				if p.err == errNeedFetch {
+					toFetch = append(toFetch, p.idx)
+					continue
+				}
+				return nil, p.err
+			}
+			result[p.idx] = p.data
+		}
+	}
+
+	if len(toFetch) > 0 {
+		// batch fetch
+		fetched, err := c.fetchBatch(ctx, keys, toFetch, expire, owner, fn)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range fetched {
+			result[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+func (c *Client) FetchBatch(keys []string, expire time.Duration, fn func(idxs []int) (map[int]string, error)) (map[int]string, error) {
+	return c.FetchBatch2(c.rdb.Context(), keys, expire, fn)
+}
+
+func (c *Client) FetchBatch2(ctx context.Context, keys []string, expire time.Duration, fn func(idxs []int) (map[int]string, error)) (map[int]string, error) {
+	if c.Options.DisableCacheRead {
+		return fn(c.keysIdx(keys))
+	}
+	// there's no weak fetch batch
+	return c.strongFetchBatch(ctx, keys, expire, fn)
+}

--- a/batch_cover_test.go
+++ b/batch_cover_test.go
@@ -16,7 +16,7 @@ var (
 )
 
 func TestDisableForBatch(t *testing.T) {
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	getFn := func(idxs []int) (map[int]string, error) {
 		return nil, nil
@@ -33,7 +33,7 @@ func TestDisableForBatch(t *testing.T) {
 }
 
 func TestErrorFetchForBatch(t *testing.T) {
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	fetchError := errors.New("fetch error")
 	fn := func(idxs []int) (map[int]string, error) {
@@ -55,7 +55,7 @@ func TestEmptyExpireForBatch(t *testing.T) {
 }
 
 func testEmptyExpireForBatch(t *testing.T, expire time.Duration) {
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	fn := func(idxs []int) (map[int]string, error) {
 		return nil, nil
@@ -91,7 +91,7 @@ func testEmptyExpireForBatch(t *testing.T, expire time.Duration) {
 }
 
 func TestPanicFetchForBatch(t *testing.T) {
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	fn := func(idxs []int) (map[int]string, error) {
 		return nil, nil

--- a/batch_cover_test.go
+++ b/batch_cover_test.go
@@ -1,0 +1,124 @@
+package rockscache
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	n = int(rand.Int31n(20) + 10)
+)
+
+func TestDisableForBatch(t *testing.T) {
+	idxs := genIdxs(0, n)
+	keys := genKeys(idxs)
+	getFn := func(idxs []int) (map[int]string, error) {
+		return nil, nil
+	}
+
+	rc := NewClient(nil, NewDefaultOptions())
+	rc.Options.DisableCacheDelete = true
+	rc.Options.DisableCacheRead = true
+
+	_, err := rc.FetchBatch2(context.Background(), keys, 60, getFn)
+	assert.Nil(t, err)
+	err = rc.TagAsDeleted2(context.Background(), keys[0])
+	assert.Nil(t, err)
+}
+
+func TestErrorFetchForBatch(t *testing.T) {
+	idxs := genIdxs(0, n)
+	keys := genKeys(idxs)
+	fetchError := errors.New("fetch error")
+	fn := func(idxs []int) (map[int]string, error) {
+		return nil, fetchError
+	}
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+	_, err := rc.FetchBatch(keys, 60, fn)
+	assert.ErrorIs(t, err, fetchError)
+
+	rc.Options.StrongConsistency = true
+	_, err = rc.FetchBatch(keys, 60, fn)
+	assert.ErrorIs(t, err, fetchError)
+}
+
+func TestEmptyExpireForBatch(t *testing.T) {
+	testEmptyExpireForBatch(t, 0)
+	testEmptyExpireForBatch(t, 10*time.Second)
+}
+
+func testEmptyExpireForBatch(t *testing.T, expire time.Duration) {
+	idxs := genIdxs(0, n)
+	keys := genKeys(idxs)
+	fn := func(idxs []int) (map[int]string, error) {
+		return nil, nil
+	}
+	fetchError := errors.New("fetch error")
+	errFn := func(idxs []int) (map[int]string, error) {
+		return nil, fetchError
+	}
+
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.EmptyExpire = expire
+
+	_, err := rc.FetchBatch(keys, 60, fn)
+	assert.Nil(t, err)
+	_, err = rc.FetchBatch(keys, 60, errFn)
+	if expire == 0 {
+		assert.ErrorIs(t, err, fetchError)
+	} else {
+		assert.Nil(t, err)
+	}
+
+	clearCache()
+	rc.Options.StrongConsistency = true
+	_, err = rc.FetchBatch(keys, 60, fn)
+	assert.Nil(t, err)
+	_, err = rc.FetchBatch(keys, 60, errFn)
+	if expire == 0 {
+		assert.ErrorIs(t, err, fetchError)
+	} else {
+		assert.Nil(t, err)
+	}
+}
+
+func TestPanicFetchForBatch(t *testing.T) {
+	idxs := genIdxs(0, n)
+	keys := genKeys(idxs)
+	fn := func(idxs []int) (map[int]string, error) {
+		return nil, nil
+	}
+	fetchError := errors.New("fetch error")
+	errFn := func(idxs []int) (map[int]string, error) {
+		panic(fetchError)
+	}
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+
+	_, err := rc.FetchBatch(keys, 60, fn)
+	assert.Nil(t, err)
+	rc.TagAsDeleted("key1")
+	_, err = rc.FetchBatch(keys, 60, errFn)
+	assert.Nil(t, err)
+	time.Sleep(20 * time.Millisecond)
+}
+
+// func TestTagAsDeletedWait(t *testing.T) {
+// 	clearCache()
+// 	rc := NewClient(rdb, NewDefaultOptions())
+// 	rc.Options.WaitReplicas = 1
+// 	rc.Options.WaitReplicasTimeout = 10
+// 	err := rc.TagAsDeleted("key1")
+// 	if getCluster() != nil {
+// 		assert.Nil(t, err)
+// 	} else {
+// 		assert.Error(t, err, fmt.Errorf("wait replicas 1 failed. result replicas: 0"))
+// 	}
+// }

--- a/batch_cover_test.go
+++ b/batch_cover_test.go
@@ -3,6 +3,7 @@ package rockscache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -110,15 +111,15 @@ func TestPanicFetchForBatch(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 }
 
-// func TestTagAsDeletedWait(t *testing.T) {
-// 	clearCache()
-// 	rc := NewClient(rdb, NewDefaultOptions())
-// 	rc.Options.WaitReplicas = 1
-// 	rc.Options.WaitReplicasTimeout = 10
-// 	err := rc.TagAsDeleted("key1")
-// 	if getCluster() != nil {
-// 		assert.Nil(t, err)
-// 	} else {
-// 		assert.Error(t, err, fmt.Errorf("wait replicas 1 failed. result replicas: 0"))
-// 	}
-// }
+func TestTagAsDeletedBatchWait(t *testing.T) {
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.WaitReplicas = 1
+	rc.Options.WaitReplicasTimeout = 10
+	err := rc.TagAsDeletedBatch([]string{"key1", "key2"})
+	if getCluster() != nil {
+		assert.Nil(t, err)
+	} else {
+		assert.Error(t, err, fmt.Errorf("wait replicas 1 failed. result replicas: 0"))
+	}
+}

--- a/batch_test.go
+++ b/batch_test.go
@@ -18,8 +18,8 @@ func genBatchDataFunc(values map[int]string, sleepMilli int) func(idxs []int) (m
 	}
 }
 
-func genIdxs(from, to int) (idxs []int) {
-	for i := from; i < to; i++ {
+func genIdxs(to int) (idxs []int) {
+	for i := 0; i < to; i++ {
 		idxs = append(idxs, i)
 	}
 	return
@@ -48,7 +48,7 @@ func TestWeakFetchBatch(t *testing.T) {
 	rc := NewClient(rdb, NewDefaultOptions())
 	began := time.Now()
 	n := int(rand.Int31n(20) + 10)
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys, values1, values2 := genKeys(idxs), genValues(n, "value_"), genValues(n, "eulav_")
 	values3 := genValues(n, "vvvv_")
 	go func() {
@@ -84,7 +84,7 @@ func TestWeakFetchBatchOverlap(t *testing.T) {
 	rc := NewClient(rdb, NewDefaultOptions())
 	began := time.Now()
 	n := 100
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	keys1, values1 := keys[:60], genValues(60, "value_")
 	keys2, values2 := keys[40:], genValues(60, "eulav_")
@@ -133,7 +133,7 @@ func TestStrongFetchBatch(t *testing.T) {
 	rc.Options.StrongConsistency = true
 	began := time.Now()
 	n := int(rand.Int31n(20) + 10)
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys, values1, values2 := genKeys(idxs), genValues(n, "value_"), genValues(n, "eulav_")
 	values3, values4 := genValues(n, "vvvv_"), genValues(n, "uuuu_")
 	go func() {
@@ -169,7 +169,7 @@ func TestStrongFetchBatchOverlap(t *testing.T) {
 	rc.Options.StrongConsistency = true
 	began := time.Now()
 	n := 100
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	keys1, values1 := keys[:60], genValues(60, "value_")
 	keys2, values2 := keys[40:], genValues(60, "eulav_")
@@ -203,7 +203,7 @@ func TestStrongFetchBatchOverlapExpire(t *testing.T) {
 	rc := NewClient(rdb, opts)
 	began := time.Now()
 	n := 100
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 	keys1, values1 := keys[:60], genValues(60, "value_")
 	keys2, values2 := keys[40:], genValues(60, "eulav_")
@@ -224,7 +224,7 @@ func TestStrongFetchBatchOverlapExpire(t *testing.T) {
 	}
 
 	time.Sleep(time.Second)
-	v, err = rc.FetchBatch(keys2, 2*time.Second, genBatchDataFunc(values2, 200))
+	v, err = rc.FetchBatch(keys2, 2*time.Second, genBatchDataFunc(values2, 100))
 	assert.Nil(t, err)
 	assert.Nil(t, err)
 	assert.Equal(t, values2, v)
@@ -238,7 +238,7 @@ func TestStrongErrorFetchBatch(t *testing.T) {
 	began := time.Now()
 
 	n := 100
-	idxs := genIdxs(0, n)
+	idxs := genIdxs(n)
 	keys := genKeys(idxs)
 
 	fetchError := errors.New("fetch error")

--- a/batch_test.go
+++ b/batch_test.go
@@ -1,0 +1,140 @@
+package rockscache
+
+import (
+	"errors"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func genBatchDataFunc(values map[int]string, sleepMilli int) func(idxs []int) (map[int]string, error) {
+	return func(idxs []int) (map[int]string, error) {
+		time.Sleep(time.Duration(sleepMilli) * time.Millisecond)
+		return values, nil
+	}
+}
+
+func genIdxs(from, to int) (idxs []int) {
+	for i := from; i < to; i++ {
+		idxs = append(idxs, i)
+	}
+	return
+}
+
+func genKeys(idxs []int) (keys []string) {
+	for _, i := range idxs {
+		suffix := strconv.Itoa(i)
+		k := "key" + suffix
+		keys = append(keys, k)
+	}
+	return
+}
+
+func genValues(idxs []int) map[int]string {
+	values := make(map[int]string)
+	for i, v := range idxs {
+		v := "value_" + strconv.Itoa(v)
+		values[i] = v
+	}
+	return values
+}
+
+func TestStrongFetchBatch(t *testing.T) {
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.StrongConsistency = true
+	began := time.Now()
+	n := int(rand.Int31n(20) + 10)
+	idxs := genIdxs(0, n)
+	keys, values := genKeys(idxs), genValues(idxs)
+	go func() {
+		dc2 := NewClient(rdb, NewDefaultOptions())
+		v, err := dc2.FetchBatch(keys, 60*time.Second, genBatchDataFunc(values, 200))
+		assert.Nil(t, err)
+		assert.Equal(t, values, v)
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	v, err := rc.FetchBatch(keys, 60*time.Second, genBatchDataFunc(values, 200))
+	assert.Nil(t, err)
+	assert.Equal(t, values, v)
+	assert.True(t, time.Since(began) > time.Duration(150)*time.Millisecond)
+
+	for _, k := range keys {
+		err = rc.TagAsDeleted(k)
+		assert.Nil(t, err)
+	}
+
+	began = time.Now()
+	nv := genValues(idxs)
+	v, err = rc.FetchBatch(keys, 60*time.Second, genBatchDataFunc(nv, 200))
+	assert.Nil(t, err)
+	assert.Equal(t, nv, v)
+	assert.True(t, time.Since(began) > time.Duration(150)*time.Millisecond)
+
+	ignored := genValues(idxs)
+	v, err = rc.FetchBatch(keys, 60*time.Second, genBatchDataFunc(ignored, 200))
+	assert.Nil(t, err)
+	assert.Equal(t, nv, v)
+}
+
+func TestStrongFetchBatchOverlap(t *testing.T) {
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.StrongConsistency = true
+	began := time.Now()
+	n := 100
+	idxs := genIdxs(0, n)
+	keys := genKeys(idxs)
+	keys1, values1 := keys[:60], genValues(idxs[:60])
+	keys2, values2 := keys[40:], genValues(idxs[40:])
+
+	go func() {
+		dc2 := NewClient(rdb, NewDefaultOptions())
+		v, err := dc2.FetchBatch(keys1, 60*time.Second, genBatchDataFunc(values1, 200))
+		assert.Nil(t, err)
+		assert.Equal(t, values1, v)
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	v, err := rc.FetchBatch(keys2, 60*time.Second, genBatchDataFunc(values2, 200))
+	assert.Nil(t, err)
+	assert.Equal(t, values2, v)
+	assert.True(t, time.Since(began) > time.Duration(150)*time.Millisecond)
+
+	v, err = rc.FetchBatch(keys1, 60*time.Second, genBatchDataFunc(values1, 200))
+	assert.Nil(t, err)
+	for i := 0; i < 40; i++ {
+		assert.Equal(t, values1[i], v[i])
+	}
+	for i := 40; i < 60; i++ {
+		assert.Equal(t, keys2[i-40], keys1[i])
+		assert.Equal(t, values2[i-40], v[i])
+	}
+}
+
+func TestStrongErrorFetchBatch(t *testing.T) {
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.StrongConsistency = true
+
+	clearCache()
+	began := time.Now()
+
+	n := 100
+	idxs := genIdxs(0, n)
+	keys := genKeys(idxs)
+
+	fetchError := errors.New("fetch error")
+	getFn := func(idxs []int) (map[int]string, error) {
+		return nil, fetchError
+	}
+	_, err := rc.FetchBatch(keys, 60*time.Second, getFn)
+	assert.Error(t, err)
+	fetchError = nil
+	_, err = rc.FetchBatch(keys, 60*time.Second, getFn)
+	assert.Nil(t, err)
+	assert.True(t, time.Since(began) < time.Duration(150)*time.Millisecond)
+}

--- a/client.go
+++ b/client.go
@@ -69,7 +69,7 @@ type Client struct {
 // for each key, rockscache client store a hash set,
 // the hash set contains the following fields:
 // value: the value of the key
-// lockUtil: the time when the lock is released.
+// lockUntil: the time when the lock is released.
 // lockOwner: the owner of the lock.
 // if a thread query the cache for data, and no cache exists, it will lock the key before querying data in DB
 func NewClient(rdb redis.UniversalClient, options Options) *Client {
@@ -92,7 +92,7 @@ func (c *Client) TagAsDeleted2(ctx context.Context, key string) error {
 	debugf("deleting: key=%s", key)
 	luaFn := func(con redisConn) error {
 		_, err := callLua(ctx, con, ` --  delete
-		redis.call('HSET', KEYS[1], 'lockUtil', 0)
+		redis.call('HSET', KEYS[1], 'lockUntil', 0)
 		redis.call('HDEL', KEYS[1], 'lockOwner')
 		redis.call('EXPIRE', KEYS[1], ARGV[1])
 			`, []string{key}, []interface{}{int64(c.Options.Delay / time.Second)})
@@ -140,9 +140,9 @@ func (c *Client) Fetch2(ctx context.Context, key string, expire time.Duration, f
 func (c *Client) luaGet(ctx context.Context, key string, owner string) ([]interface{}, error) {
 	res, err := callLua(ctx, c.rdb, ` -- luaGet
 	local v = redis.call('HGET', KEYS[1], 'value')
-	local lu = redis.call('HGET', KEYS[1], 'lockUtil')
+	local lu = redis.call('HGET', KEYS[1], 'lockUntil')
 	if lu ~= false and tonumber(lu) < tonumber(ARGV[1]) or lu == false and v == false then
-		redis.call('HSET', KEYS[1], 'lockUtil', ARGV[2])
+		redis.call('HSET', KEYS[1], 'lockUntil', ARGV[2])
 		redis.call('HSET', KEYS[1], 'lockOwner', ARGV[3])
 		return { v, 'LOCKED' }
 	end
@@ -162,7 +162,7 @@ func (c *Client) luaSet(ctx context.Context, key string, value string, expire in
 			return
 	end
 	redis.call('HSET', KEYS[1], 'value', ARGV[1])
-	redis.call('HDEL', KEYS[1], 'lockUtil')
+	redis.call('HDEL', KEYS[1], 'lockUntil')
 	redis.call('HDEL', KEYS[1], 'lockOwner')
 	redis.call('EXPIRE', KEYS[1], ARGV[3])
 	`, []string{key}, []interface{}{value, owner, expire})
@@ -244,17 +244,17 @@ func (c *Client) RawSet(ctx context.Context, key string, value string, expire ti
 
 // LockForUpdate locks the key, used in very strict strong consistency mode
 func (c *Client) LockForUpdate(ctx context.Context, key string, owner string) error {
-	lockUtil := math.Pow10(10)
+	lockUntil := math.Pow10(10)
 	res, err := callLua(ctx, c.rdb, ` -- luaLock
-	local lu = redis.call('HGET', KEYS[1], 'lockUtil')
+	local lu = redis.call('HGET', KEYS[1], 'lockUntil')
 	local lo = redis.call('HGET', KEYS[1], 'lockOwner')
 	if lu == false or tonumber(lu) < tonumber(ARGV[2]) or lo == ARGV[1] then
-		redis.call('HSET', KEYS[1], 'lockUtil', ARGV[2])
+		redis.call('HSET', KEYS[1], 'lockUntil', ARGV[2])
 		redis.call('HSET', KEYS[1], 'lockOwner', ARGV[1])
 		return 'LOCKED'
 	end
 	return lo
-	`, []string{key}, []interface{}{owner, lockUtil})
+	`, []string{key}, []interface{}{owner, lockUntil})
 	if err == nil && res != "LOCKED" {
 		return fmt.Errorf("%s has been locked by %s", key, res)
 	}
@@ -266,7 +266,7 @@ func (c *Client) UnlockForUpdate(ctx context.Context, key string, owner string) 
 	_, err := callLua(ctx, c.rdb, ` -- luaUnlock
 	local lo = redis.call('HGET', KEYS[1], 'lockOwner')
 	if lo == ARGV[1] then
-		redis.call('HSET', KEYS[1], 'lockUtil', 0)
+		redis.call('HSET', KEYS[1], 'lockUntil', 0)
 		redis.call('HDEL', KEYS[1], 'lockOwner')
 	end
 	`, []string{key}, []interface{}{owner})

--- a/client_test.go
+++ b/client_test.go
@@ -127,6 +127,25 @@ func TestStrongFetch(t *testing.T) {
 
 }
 
+func TestStrongErrorFetch(t *testing.T) {
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.StrongConsistency = true
+
+	clearCache()
+	began := time.Now()
+
+	fetchError := errors.New("fetch error")
+	getFn := func() (string, error) {
+		return "", fetchError
+	}
+	_, err := rc.Fetch(rdbKey, 60*time.Second, getFn)
+	assert.Error(t, err)
+	fetchError = nil
+	_, err = rc.Fetch(rdbKey, 60*time.Second, getFn)
+	assert.Nil(t, err)
+	assert.True(t, time.Since(began) < time.Duration(150)*time.Millisecond)
+}
+
 func TestWeakErrorFetch(t *testing.T) {
 	rc := NewClient(rdb, NewDefaultOptions())
 

--- a/helper/README-cn.md
+++ b/helper/README-cn.md
@@ -17,6 +17,7 @@
 - 防穿透
 - 防雪崩
 - 非常易用：仅提供极简的两个函数，对应用无要求
+- 提供批量查询接口
 
 ## 使用
 本缓存库采用最常见的`更新DB后，删除缓存`的缓存管理策略
@@ -38,6 +39,32 @@ v, err := rc.Fetch("key1", 300, func()(string, error) {
 ### 删除缓存
 ``` Go
 rc.TagAsDeleted(key)
+```
+
+## 批量查询接口使用
+
+### 批量读取缓存
+``` Go
+import "github.com/dtm-labs/rockscache"
+
+// 使用默认选项生成rockscache的客户端
+rc := rockscache.NewClient(redisClient, NewDefaultOptions())
+
+// 使用FetchBatch获取数据，第一个参数是数据的keys列表，第二个参数为数据过期时间，第三个参数为缓存不存在时，数据获取函数
+// 数据获取函数的参数为 keys 列表的下标数组，表示 keys 中没命中缓存的 key 的下标，通过这些下标可以构造批量查询条件；返回值是以下标为 key，字符串为值的 map
+v, err := rc.FetchBatch([]string{"key1", "key2", "key3"}, 300, func(idxs []int) (map[int]string, error) {
+    // 从数据库或其他渠道获取数据
+    values := make(map[int]string)
+    for _, i := range idxs {
+        values[i] = fmt.Sprintf("value%d", i)
+    }
+    return values, nil
+})
+```
+
+### 批量删除缓存
+``` Go
+rc.TagAsDeletedBatch(keys)
 ```
 
 ## 最终一致


### PR DESCRIPTION
Batch processing could be very useful when you need to fetch a series of data, which could reduce the database query times and the redis query times, therefore reduce api latency.

The feature of this implementation is as below:

1. Support both strong consistency and weak consistency.
2. Support batch tag as deleted
3. Only 1 redis query, 1 database query and 1 redis set for batch fetch in fast path.
4. Sleep and wait concurrently when locked by others (slow path)
5. Fetch only missing data from database.