### PR TITLE
Support EVALSHA

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -296,6 +296,7 @@ func (c *Client) strongFetchBatch(ctx context.Context, keys []string, expire tim
 					select {
 					case <-ctx.Done():
 						ch <- pair{idx: i, err: ctx.Err()}
+						return
 					case <-ticker.C:
 						// equal to time.Sleep(c.Options.LockSleep) but can be canceled
 					}

--- a/batch.go
+++ b/batch.go
@@ -192,10 +192,25 @@ func (c *Client) weakFetchBatch(ctx context.Context, keys []string, expire time.
 			go func(i int) {
 				defer wg.Done()
 				r, err := c.luaGet(ctx, keys[i], owner)
+				ticker := time.NewTimer(c.Options.LockSleep)
+				defer ticker.Stop()
 				for err == nil && r[0] == nil && r[1].(string) != locked {
 					debugf("batch weak: empty result for %s locked by other, so sleep %s", keys[i], c.Options.LockSleep.String())
-					time.Sleep(c.Options.LockSleep)
+					select {
+					case <-ctx.Done():
+						ch <- pair{idx: i, err: ctx.Err()}
+						return
+					case <-ticker.C:
+						// equal to time.Sleep(c.Options.LockSleep) but can be canceled
+					}
 					r, err = c.luaGet(ctx, keys[i], owner)
+					// Reset ticker after luaGet
+					// If we reset ticker before luaGet, since luaGet takes a period of time,
+					// the actual sleep time will be shorter than expected
+					if !ticker.Stop() && len(ticker.C) > 0 {
+						<-ticker.C
+					}
+					ticker.Reset(c.Options.LockSleep)
 				}
 				if err != nil {
 					ch <- pair{idx: i, data: "", err: err}
@@ -302,10 +317,24 @@ func (c *Client) strongFetchBatch(ctx context.Context, keys []string, expire tim
 			go func(i int) {
 				defer wg.Done()
 				r, err := c.luaGet(ctx, keys[i], owner)
+				ticker := time.NewTimer(c.Options.LockSleep)
+				defer ticker.Stop()
 				for err == nil && r[1] != nil && r[1] != locked { // locked by other
 					debugf("batch: locked by other, so sleep %s", c.Options.LockSleep)
-					time.Sleep(c.Options.LockSleep)
+					select {
+					case <-ctx.Done():
+						ch <- pair{idx: i, err: ctx.Err()}
+					case <-ticker.C:
+						// equal to time.Sleep(c.Options.LockSleep) but can be canceled
+					}
 					r, err = c.luaGet(ctx, keys[i], owner)
+					// Reset ticker after luaGet
+					// If we reset ticker before luaGet, since luaGet takes a period of time,
+					// the actual sleep time will be shorter than expected
+					if !ticker.Stop() && len(ticker.C) > 0 {
+						<-ticker.C
+					}
+					ticker.Reset(c.Options.LockSleep)
 				}
 				if err != nil {
 					ch <- pair{idx: i, data: "", err: err}

--- a/batch_cover_test.go
+++ b/batch_cover_test.go
@@ -133,28 +133,28 @@ func TestWeakFetchBatchCanceled(t *testing.T) {
 	values3 := genValues(n, "vvvv_")
 	go func() {
 		dc2 := NewClient(rdb, NewDefaultOptions())
-		v, err := dc2.FetchBatch(keys, 60*time.Second, genBatchDataFunc(values1, 400))
+		v, err := dc2.FetchBatch(keys, 60*time.Second, genBatchDataFunc(values1, 450))
 		assert.Nil(t, err)
 		assert.Equal(t, values1, v)
 	}()
 	time.Sleep(20 * time.Millisecond)
 
 	began := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, err := rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values2, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
 	began = time.Now()
 	_, err = rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values3, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 }
 
 func TestStrongFetchBatchCanceled(t *testing.T) {
@@ -167,26 +167,26 @@ func TestStrongFetchBatchCanceled(t *testing.T) {
 	values3 := genValues(n, "vvvv_")
 	go func() {
 		dc2 := NewClient(rdb, NewDefaultOptions())
-		v, err := dc2.FetchBatch(keys, 60*time.Second, genBatchDataFunc(values1, 400))
+		v, err := dc2.FetchBatch(keys, 60*time.Second, genBatchDataFunc(values1, 450))
 		assert.Nil(t, err)
 		assert.Equal(t, values1, v)
 	}()
 	time.Sleep(20 * time.Millisecond)
 
 	began := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, err := rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values2, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
 	began = time.Now()
 	_, err = rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values3, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 }

--- a/batch_cover_test.go
+++ b/batch_cover_test.go
@@ -144,7 +144,7 @@ func TestWeakFetchBatchCanceled(t *testing.T) {
 	defer cancel()
 	_, err := rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values2, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
@@ -154,7 +154,7 @@ func TestWeakFetchBatchCanceled(t *testing.T) {
 	began = time.Now()
 	_, err = rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values3, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 }
 
 func TestStrongFetchBatchCanceled(t *testing.T) {
@@ -178,7 +178,7 @@ func TestStrongFetchBatchCanceled(t *testing.T) {
 	defer cancel()
 	_, err := rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values2, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
@@ -188,5 +188,5 @@ func TestStrongFetchBatchCanceled(t *testing.T) {
 	began = time.Now()
 	_, err = rc.FetchBatch2(ctx, keys, 60*time.Second, genBatchDataFunc(values3, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 }

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package rockscache
 import (
 	"context"
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
 	"time"
@@ -193,10 +194,25 @@ func (c *Client) weakFetch(ctx context.Context, key string, expire time.Duration
 	debugf("weakFetch: key=%s", key)
 	owner := shortuuid.New()
 	r, err := c.luaGet(ctx, key, owner)
+	ticker := time.NewTimer(c.Options.LockSleep)
+	defer ticker.Stop()
 	for err == nil && r[0] == nil && r[1].(string) != locked {
 		debugf("empty result for %s locked by other, so sleep %s", key, c.Options.LockSleep.String())
-		time.Sleep(c.Options.LockSleep)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			log.Printf("ticker")
+			// equal to time.Sleep(c.Options.LockSleep) but can be canceled
+		}
 		r, err = c.luaGet(ctx, key, owner)
+		// Reset ticker after luaGet
+		// If we reset ticker before luaGet, since luaGet takes a period of time,
+		// the actual sleep time will be shorter than expected
+		if !ticker.Stop() && len(ticker.C) > 0 {
+			<-ticker.C
+		}
+		ticker.Reset(c.Options.LockSleep)
 	}
 	if err != nil {
 		return "", err
@@ -217,10 +233,25 @@ func (c *Client) strongFetch(ctx context.Context, key string, expire time.Durati
 	debugf("strongFetch: key=%s", key)
 	owner := shortuuid.New()
 	r, err := c.luaGet(ctx, key, owner)
+	ticker := time.NewTimer(c.Options.LockSleep)
+	defer ticker.Stop()
 	for err == nil && r[1] != nil && r[1] != locked { // locked by other
 		debugf("locked by other, so sleep %s", c.Options.LockSleep)
-		time.Sleep(c.Options.LockSleep)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			log.Printf("ticker")
+			// equal to time.Sleep(c.Options.LockSleep) but can be canceled
+		}
 		r, err = c.luaGet(ctx, key, owner)
+		// Reset ticker after luaGet
+		// If we reset ticker before luaGet, since luaGet takes a period of time,
+		// the actual sleep time will be shorter than expected
+		if !ticker.Stop() && len(ticker.C) > 0 {
+			<-ticker.C
+		}
+		ticker.Reset(c.Options.LockSleep)
 	}
 	if err != nil {
 		return "", err

--- a/client.go
+++ b/client.go
@@ -94,12 +94,8 @@ func (c *Client) TagAsDeleted2(ctx context.Context, key string) error {
 		return nil
 	}
 	debugf("deleting: key=%s", key)
-	luaFn := func(con redisConn) error {
-		_, err := callLua(ctx, con, ` --  delete
-		redis.call('HSET', KEYS[1], 'lockUntil', 0)
-		redis.call('HDEL', KEYS[1], 'lockOwner')
-		redis.call('EXPIRE', KEYS[1], ARGV[1])
-			`, []string{key}, []interface{}{int64(c.Options.Delay / time.Second)})
+	luaFn := func(con redis.Scripter) error {
+		_, err := callLua(ctx, con, deleteScript, []string{key}, []interface{}{int64(c.Options.Delay / time.Second)})
 		return err
 	}
 	if c.Options.WaitReplicas > 0 {
@@ -142,16 +138,7 @@ func (c *Client) Fetch2(ctx context.Context, key string, expire time.Duration, f
 }
 
 func (c *Client) luaGet(ctx context.Context, key string, owner string) ([]interface{}, error) {
-	res, err := callLua(ctx, c.rdb, ` -- luaGet
-	local v = redis.call('HGET', KEYS[1], 'value')
-	local lu = redis.call('HGET', KEYS[1], 'lockUntil')
-	if lu ~= false and tonumber(lu) < tonumber(ARGV[1]) or lu == false and v == false then
-		redis.call('HSET', KEYS[1], 'lockUntil', ARGV[2])
-		redis.call('HSET', KEYS[1], 'lockOwner', ARGV[3])
-		return { v, 'LOCKED' }
-	end
-	return {v, lu}
-	`, []string{key}, []interface{}{now(), now() + int64(c.Options.LockExpire/time.Second), owner})
+	res, err := callLua(ctx, c.rdb, getScript, []string{key}, []interface{}{now(), now() + int64(c.Options.LockExpire/time.Second), owner})
 	debugf("luaGet return: %v, %v", res, err)
 	if err != nil {
 		return nil, err
@@ -160,16 +147,7 @@ func (c *Client) luaGet(ctx context.Context, key string, owner string) ([]interf
 }
 
 func (c *Client) luaSet(ctx context.Context, key string, value string, expire int, owner string) error {
-	_, err := callLua(ctx, c.rdb, `-- luaSet
-	local o = redis.call('HGET', KEYS[1], 'lockOwner')
-	if o ~= ARGV[2] then
-			return
-	end
-	redis.call('HSET', KEYS[1], 'value', ARGV[1])
-	redis.call('HDEL', KEYS[1], 'lockUntil')
-	redis.call('HDEL', KEYS[1], 'lockOwner')
-	redis.call('EXPIRE', KEYS[1], ARGV[3])
-	`, []string{key}, []interface{}{value, owner, expire})
+	_, err := callLua(ctx, c.rdb, setScript, []string{key}, []interface{}{value, owner, expire})
 	return err
 }
 
@@ -279,16 +257,7 @@ func (c *Client) RawSet(ctx context.Context, key string, value string, expire ti
 // LockForUpdate locks the key, used in very strict strong consistency mode
 func (c *Client) LockForUpdate(ctx context.Context, key string, owner string) error {
 	lockUntil := math.Pow10(10)
-	res, err := callLua(ctx, c.rdb, ` -- luaLock
-	local lu = redis.call('HGET', KEYS[1], 'lockUntil')
-	local lo = redis.call('HGET', KEYS[1], 'lockOwner')
-	if lu == false or tonumber(lu) < tonumber(ARGV[2]) or lo == ARGV[1] then
-		redis.call('HSET', KEYS[1], 'lockUntil', ARGV[2])
-		redis.call('HSET', KEYS[1], 'lockOwner', ARGV[1])
-		return 'LOCKED'
-	end
-	return lo
-	`, []string{key}, []interface{}{owner, lockUntil})
+	res, err := callLua(ctx, c.rdb, lockScript, []string{key}, []interface{}{owner, lockUntil})
 	if err == nil && res != "LOCKED" {
 		return fmt.Errorf("%s has been locked by %s", key, res)
 	}
@@ -297,13 +266,6 @@ func (c *Client) LockForUpdate(ctx context.Context, key string, owner string) er
 
 // UnlockForUpdate unlocks the key, used in very strict strong consistency mode
 func (c *Client) UnlockForUpdate(ctx context.Context, key string, owner string) error {
-	_, err := callLua(ctx, c.rdb, ` -- luaUnlock
-	local lo = redis.call('HGET', KEYS[1], 'lockOwner')
-	if lo == ARGV[1] then
-		redis.call('HSET', KEYS[1], 'lockUntil', 0)
-		redis.call('HDEL', KEYS[1], 'lockOwner')
-		redis.call('EXPIRE', KEYS[1], ARGV[2])
-	end
-	`, []string{key}, []interface{}{owner, c.Options.LockExpire / time.Second})
+	_, err := callLua(ctx, c.rdb, unlockScript, []string{key}, []interface{}{owner, c.Options.LockExpire / time.Second})
 	return err
 }

--- a/client_test.go
+++ b/client_test.go
@@ -147,6 +147,37 @@ func TestStrongErrorFetch(t *testing.T) {
 	assert.True(t, time.Since(began) < time.Duration(150)*time.Millisecond)
 }
 
+func TestStrongFetchCanceled(t *testing.T) {
+	clearCache()
+	rc := NewClient(rdb, NewDefaultOptions())
+	rc.Options.StrongConsistency = true
+	expected := "value1"
+	go func() {
+		dc2 := NewClient(rdb, NewDefaultOptions())
+		v, err := dc2.Fetch(rdbKey, 60*time.Second, genDataFunc(expected, 400))
+		assert.Nil(t, err)
+		assert.Equal(t, expected, v)
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	began := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+
+	ctx, cancel = context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	began = time.Now()
+	_, err = rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+}
+
 func TestWeakErrorFetch(t *testing.T) {
 	rc := NewClient(rdb, NewDefaultOptions())
 
@@ -163,6 +194,37 @@ func TestWeakErrorFetch(t *testing.T) {
 	_, err = rc.Fetch(rdbKey, 60*time.Second, getFn)
 	assert.Nil(t, err)
 	assert.True(t, time.Since(began) < time.Duration(150)*time.Millisecond)
+}
+
+func TestWeakFetchCanceled(t *testing.T) {
+	rc := NewClient(rdb, NewDefaultOptions())
+
+	clearCache()
+	expected := "value1"
+	go func() {
+		dc2 := NewClient(rdb, NewDefaultOptions())
+		v, err := dc2.Fetch(rdbKey, 60*time.Second, genDataFunc(expected, 400))
+		assert.Nil(t, err)
+		assert.Equal(t, expected, v)
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	began := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+
+	ctx, cancel = context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	began = time.Now()
+	_, err = rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
 }
 
 func TestRawGet(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -148,6 +148,7 @@ func TestStrongErrorFetch(t *testing.T) {
 	assert.True(t, time.Since(began) < time.Duration(150)*time.Millisecond)
 }
 
+// nolint: unparam
 func assertEqualDuration(t *testing.T, expected, actual time.Duration) {
 	t.Helper()
 	delta := expected - actual

--- a/client_test.go
+++ b/client_test.go
@@ -155,28 +155,28 @@ func TestStrongFetchCanceled(t *testing.T) {
 	expected := "value1"
 	go func() {
 		dc2 := NewClient(rdb, NewDefaultOptions())
-		v, err := dc2.Fetch(rdbKey, 60*time.Second, genDataFunc(expected, 400))
+		v, err := dc2.Fetch(rdbKey, 60*time.Second, genDataFunc(expected, 450))
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}()
 	time.Sleep(20 * time.Millisecond)
 
 	began := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, err := rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
 	began = time.Now()
 	_, err = rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 }
 
 func TestWeakErrorFetch(t *testing.T) {
@@ -204,28 +204,28 @@ func TestWeakFetchCanceled(t *testing.T) {
 	expected := "value1"
 	go func() {
 		dc2 := NewClient(rdb, NewDefaultOptions())
-		v, err := dc2.Fetch(rdbKey, 60*time.Second, genDataFunc(expected, 400))
+		v, err := dc2.Fetch(rdbKey, 60*time.Second, genDataFunc(expected, 450))
 		assert.Nil(t, err)
 		assert.Equal(t, expected, v)
 	}()
 	time.Sleep(20 * time.Millisecond)
 
 	began := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, err := rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
 	began = time.Now()
 	_, err = rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.True(t, time.Since(began) < time.Duration(110)*time.Millisecond)
+	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
 }
 
 func TestRawGet(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -65,6 +65,7 @@ func TestWeakFetch(t *testing.T) {
 
 	clearCache()
 	began := time.Now()
+	// nolint: goconst
 	expected := "value1"
 	go func() {
 		dc2 := NewClient(rdb, NewDefaultOptions())

--- a/client_test.go
+++ b/client_test.go
@@ -148,6 +148,16 @@ func TestStrongErrorFetch(t *testing.T) {
 	assert.True(t, time.Since(began) < time.Duration(150)*time.Millisecond)
 }
 
+func assertEqualDuration(t *testing.T, expected, actual time.Duration) {
+	t.Helper()
+	delta := expected - actual
+	if delta < 0 {
+		delta = -delta
+	}
+	t.Logf("expected=%s, actual=%s, delta=%s", expected, actual, delta)
+	assert.Less(t, delta, time.Duration(2)*time.Millisecond)
+}
+
 func TestStrongFetchCanceled(t *testing.T) {
 	clearCache()
 	rc := NewClient(rdb, NewDefaultOptions())
@@ -166,7 +176,7 @@ func TestStrongFetchCanceled(t *testing.T) {
 	defer cancel()
 	_, err := rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
@@ -176,7 +186,7 @@ func TestStrongFetchCanceled(t *testing.T) {
 	began = time.Now()
 	_, err = rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 }
 
 func TestWeakErrorFetch(t *testing.T) {
@@ -215,7 +225,7 @@ func TestWeakFetchCanceled(t *testing.T) {
 	defer cancel()
 	_, err := rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
@@ -225,7 +235,7 @@ func TestWeakFetchCanceled(t *testing.T) {
 	began = time.Now()
 	_, err = rc.Fetch2(ctx, rdbKey, 60*time.Second, genDataFunc(expected, 200))
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.Less(t, time.Since(began), time.Duration(210)*time.Millisecond)
+	assertEqualDuration(t, time.Duration(200)*time.Millisecond, time.Since(began))
 }
 
 func TestRawGet(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/lithammer/shortuuid v3.0.0+incompatible
 	github.com/redis/go-redis/v9 v9.0.3
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/sync v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/script.go
+++ b/script.go
@@ -1,0 +1,77 @@
+package rockscache
+
+import "github.com/redis/go-redis/v9"
+
+var (
+	deleteScript = redis.NewScript(`redis.call('HSET', KEYS[1], 'lockUntil', 0)
+redis.call('HDEL', KEYS[1], 'lockOwner')
+redis.call('EXPIRE', KEYS[1], ARGV[1])`)
+
+	getScript = redis.NewScript(`local v = redis.call('HGET', KEYS[1], 'value')
+local lu = redis.call('HGET', KEYS[1], 'lockUntil')
+if lu ~= false and tonumber(lu) < tonumber(ARGV[1]) or lu == false and v == false then
+	redis.call('HSET', KEYS[1], 'lockUntil', ARGV[2])
+	redis.call('HSET', KEYS[1], 'lockOwner', ARGV[3])
+	return { v, 'LOCKED' }
+end
+return {v, lu}`)
+
+	setScript = redis.NewScript(`local o = redis.call('HGET', KEYS[1], 'lockOwner')
+if o ~= ARGV[2] then
+		return
+end
+redis.call('HSET', KEYS[1], 'value', ARGV[1])
+redis.call('HDEL', KEYS[1], 'lockUntil')
+redis.call('HDEL', KEYS[1], 'lockOwner')
+redis.call('EXPIRE', KEYS[1], ARGV[3])`)
+
+	lockScript = redis.NewScript(`local lu = redis.call('HGET', KEYS[1], 'lockUntil')
+local lo = redis.call('HGET', KEYS[1], 'lockOwner')
+if lu == false or tonumber(lu) < tonumber(ARGV[2]) or lo == ARGV[1] then
+	redis.call('HSET', KEYS[1], 'lockUntil', ARGV[2])
+	redis.call('HSET', KEYS[1], 'lockOwner', ARGV[1])
+	return 'LOCKED'
+end
+return lo`)
+
+	unlockScript = redis.NewScript(`local lo = redis.call('HGET', KEYS[1], 'lockOwner')
+if lo == ARGV[1] then
+	redis.call('HSET', KEYS[1], 'lockUntil', 0)
+	redis.call('HDEL', KEYS[1], 'lockOwner')
+	redis.call('EXPIRE', KEYS[1], ARGV[2])
+end`)
+
+	getBatchScript = redis.NewScript(`local rets = {}
+for i, key in ipairs(KEYS)
+do
+	local v = redis.call('HGET', key, 'value')
+	local lu = redis.call('HGET', key, 'lockUntil')
+	if lu ~= false and tonumber(lu) < tonumber(ARGV[1]) or lu == false and v == false then
+		redis.call('HSET', key, 'lockUntil', ARGV[2])
+		redis.call('HSET', key, 'lockOwner', ARGV[3])
+		table.insert(rets, { v, 'LOCKED' })
+	else
+		table.insert(rets, {v, lu})
+	end
+end
+return rets`)
+
+	setBatchScript = redis.NewScript(`local n = #KEYS
+for i, key in ipairs(KEYS)
+do
+	local o = redis.call('HGET', key, 'lockOwner')
+	if o ~= ARGV[1] then
+			return
+	end
+	redis.call('HSET', key, 'value', ARGV[i+1])
+	redis.call('HDEL', key, 'lockUntil')
+	redis.call('HDEL', key, 'lockOwner')
+	redis.call('EXPIRE', key, ARGV[i+1+n])
+end`)
+
+	deleteBatchScript = redis.NewScript(`for i, key in ipairs(KEYS) do
+	redis.call('HSET', key, 'lockUntil', 0)
+	redis.call('HDEL', key, 'lockOwner')
+	redis.call('EXPIRE', key, ARGV[1])
+end`)
+)

--- a/utils.go
+++ b/utils.go
@@ -25,13 +25,19 @@ func now() int64 {
 	return time.Now().Unix()
 }
 
-type redisConn interface {
-	Eval(ctx context.Context, script string, keys []string, args ...interface{}) *redis.Cmd
-}
-
-func callLua(ctx context.Context, rdb redisConn, script string, keys []string, args []interface{}) (interface{}, error) {
-	debugf("callLua: script=%s, keys=%v, args=%v", script, keys, args)
-	v, err := rdb.Eval(ctx, script, keys, args).Result()
+func callLua(ctx context.Context, rdb redis.Scripter, script *redis.Script, keys []string, args []interface{}) (interface{}, error) {
+	debugf("callLua: script=%s, keys=%v, args=%v", script.Hash(), keys, args)
+	r := script.EvalSha(ctx, rdb, keys, args)
+	if redis.HasErrorPrefix(r.Err(), "NOSCRIPT") {
+		// try load script
+		if err := script.Load(ctx, rdb).Err(); err != nil {
+			debugf("callLua: load script failed: %v", err)
+			r = script.Eval(ctx, rdb, keys, args) // fallback to EVAL
+		} else {
+			r = script.EvalSha(ctx, rdb, keys, args) // retry EVALSHA
+		}
+	}
+	v, err := r.Result()
 	if err == redis.Nil {
 		err = nil
 	}


### PR DESCRIPTION
- Support `EVALSHA` to reduce network & cpu overhead of `EVAL`.
- Support cancellable sleep instead of `time.Sleep` for failfast on context cancelled.